### PR TITLE
add missing module in hackage tarball.

### DIFF
--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -64,6 +64,8 @@ test-suite oidc-client-spec
   default-language:     Haskell2010
   ghc-options:          -Wall
   main-is:              Spec.hs
+  other-modules:
+      Spec.Client
   build-depends:
       base
     , hspec


### PR DESCRIPTION
test/Spec/Client.hs is missing in hackage tarball.
