### PR TITLE
Add nonce to sample + Make the sample compilable by current LTS Haskell

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,11 @@
-resolver: lts-7.24
+resolver: lts-13.14
 
 packages:
   - '.'
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
-  - scotty-cookie-0.1.0.3
+- scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Parameter `nonce` is strongly recommended to protect from replay-attack.