### PR TITLE
Preserve the raw JWT in the tokens record returned by `validate`

### DIFF
--- a/nix/20_03.nix
+++ b/nix/20_03.nix
@@ -1,0 +1,4 @@
+(import ./fetchNixpkgs.nix) {
+  rev    = "5272327b81ed355bbed5659b8d303cf2979b6953";
+  sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
+}

--- a/nix/fetchNixpkgs.nix
+++ b/nix/fetchNixpkgs.nix
@@ -1,0 +1,8 @@
+{ rev                             # The Git revision of nixpkgs to fetch
+, sha256                          # The SHA256 of the downloaded data
+}:
+
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+  inherit sha256;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,33 @@
+let
+  config   = { allowUnfree = true; };
+  overlays = [
+    (newPkgs: oldPkgs: rec {
+
+      haskellPackages = oldPkgs.haskellPackages.override {
+        overrides = haskellPackagesNew: _: {
+          oidc-client = haskellPackagesNew.callCabal2nix "oidc-client" ./. { };
+        };
+      };
+
+    })
+  ];
+
+  nixpkgs = import ./nix/20_03.nix;
+  pkgs    = import nixpkgs { inherit config overlays; };
+
+  oidc-client-shell = pkgs.haskellPackages.shellFor {
+    withHoogle = false;
+    packages = p: [
+      p.oidc-client
+    ];
+
+    buildInputs = [
+      pkgs.ghcid
+    ];
+  };
+
+in
+
+  { inherit (pkgs.haskellPackages) oidc-client;
+    inherit oidc-client-shell;
+  }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./release.nix).oidc-client-shell

--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -158,6 +158,7 @@ validate oidc savedNonce tres = do
           accessToken  = I.accessToken tres
         , tokenType    = I.tokenType tres
         , idToken      = claims'
+        , idTokenJwt   = jwt'
         , expiresIn    = I.expiresIn tres
         , refreshToken = I.refreshToken tres
         }

--- a/src/Web/OIDC/Client/Tokens.hs
+++ b/src/Web/OIDC/Client/Tokens.hs
@@ -38,6 +38,7 @@ data Tokens a = Tokens
     { accessToken  :: Text
     , tokenType    :: Text
     , idToken      :: IdTokenClaims a
+    , idTokenJwt   :: Jwt
     , expiresIn    :: Maybe Integer
     , refreshToken :: Maybe Text
     }


### PR DESCRIPTION
I'm proposing two changes in this pull request. The first one adds basic Nix code for a developer environment that includes the dependencies and ghcid: 7f84ad0. I realize this change may be controversial and I'm fine with dropping it if the maintainers don't wish to include it.

The second change, 5166f8d, merely adds the raw JWT token to the `Tokens` data type. The primary motivation behind this is token re-validation, e.g. in a microservices context where authenticated requests between services carry the `id_token`, revalidating the token at the service boundary is necessary and impossible without the original JWT minted by the provider.