### PR TITLE
s/JwtExceptoin/JwtException/

### DIFF
--- a/src/Web/OIDC/Client/Tokens.hs
+++ b/src/Web/OIDC/Client/Tokens.hs
@@ -84,7 +84,7 @@ validateIdToken oidc jwt' = do
         Right (Unsecured payload) -> liftIO . throwIO $ UnsecuredJwt payload
         Right (Jws (_header, payload)) -> parsePayload payload
         Right (Jwe (_header, payload)) -> parsePayload payload
-        Left err -> liftIO . throwIO $ JwtExceptoin err
+        Left err -> liftIO . throwIO $ JwtException err
   where
     tryDecode jwks token = \case
         P.JwsAlgJson  alg -> liftIO $ Jwt.decode jwks (Just $ Jwt.JwsEncoding alg) token

--- a/src/Web/OIDC/Client/Types.hs
+++ b/src/Web/OIDC/Client/Types.hs
@@ -53,7 +53,7 @@ data OpenIdException =
     | InternalHttpException HttpException
     | JsonException Text
     | UnsecuredJwt ByteString
-    | JwtExceptoin JwtError
+    | JwtException JwtError
     | ValidationException Text
   deriving (Show, Typeable)
 


### PR DESCRIPTION
This change fixes the spelling of the `JwtException` variant of the `OpenIdException` data type.