### PR TITLE
s/Incosistent/Inconsistent/

### DIFF
--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -82,7 +82,7 @@ getValidTokens store oidc mgr stateFromIdP code = do
           result <- liftIO $ requestTokens oidc savedNonce code mgr
           sessionStoreDelete store
           return result
-      else throwM $ ValidationException $ "Incosistent state: " <> decodeUtf8 stateFromIdP
+      else throwM $ ValidationException $ "Inconsistent state: " <> decodeUtf8 stateFromIdP
 
 -- | Make URL for Authorization Request.
 {-# WARNING getAuthenticationRequestUrl "This function doesn't manage state and nonce. Use prepareAuthenticationRequestUrl only unless your IdP doesn't support state and/or nonce." #-}

--- a/src/Web/OIDC/Client/IdTokenFlow.hs
+++ b/src/Web/OIDC/Client/IdTokenFlow.hs
@@ -72,7 +72,7 @@ getValidIdTokenClaims store oidc stateFromIdP getIdToken = do
                 $ throwIO
                 $ ValidationException "Nonce does not match request."
           pure idToken
-      else liftIO $ throwIO $ ValidationException $ "Incosistent state: " <> decodeUtf8 stateFromIdP
+      else liftIO $ throwIO $ ValidationException $ "Inconsistent state: " <> decodeUtf8 stateFromIdP
 
 -- | Make URL for Authorization Request.
 {-# WARNING getAuthenticationRequestUrl "This function doesn't manage state and nonce. Use prepareAuthenticationRequestUrl only unless your IdP doesn't support state and/or nonce." #-}


### PR DESCRIPTION
This change just fixes the spelling of an error message.