### PR TITLE
Update nixpkgs pin 20.03 -> 21.05

### DIFF
--- a/nix/20_03.nix
+++ b/nix/20_03.nix
@@ -1,4 +1,0 @@
-(import ./fetchNixpkgs.nix) {
-  rev    = "5272327b81ed355bbed5659b8d303cf2979b6953";
-  sha256 = "0182ys095dfx02vl2a20j1hz92dx3mfgz2a6fhn31bqlp1wa8hlq";
-}

--- a/nix/21_05.nix
+++ b/nix/21_05.nix
@@ -1,0 +1,4 @@
+(import ./fetchNixpkgs.nix) {
+  rev    = "7e9b0dff974c89e070da1ad85713ff3c20b0ca97";
+  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+}

--- a/release.nix
+++ b/release.nix
@@ -12,7 +12,7 @@ let
     })
   ];
 
-  nixpkgs = import ./nix/20_03.nix;
+  nixpkgs = import ./nix/21_05.nix;
   pkgs    = import nixpkgs { inherit config overlays; };
 
   oidc-client-shell = pkgs.haskellPackages.shellFor {


### PR DESCRIPTION
This change updates the nixpkgs pin from the `20.03` release to the latest release `21.05`.