### PR TITLE
Use ReaderT to carry the OIDC settings

### DIFF
--- a/examples/scotty/Main.hs
+++ b/examples/scotty/Main.hs
@@ -108,7 +108,7 @@ run' = do
 
         sid <- genSessionId cprg
         let store = sessionStoreFromSession cprg ssm sid
-        loc <- liftIO $ O.prepareAuthenticationRequestUrl store oidc [O.email, O.profile] []
+        loc <- liftIO $ runReaderT (O.prepareAuthenticationRequestUrl store [O.email, O.profile] []) oidc
         setSimpleCookie cookieName sid
         redirect . TL.pack . show $ loc
 
@@ -133,7 +133,7 @@ run' = do
                 let store = sessionStoreFromSession cprg ssm sid
                 state <- param "state"
                 code  <- param "code"
-                tokens <- liftIO $ O.getValidTokens store oidc mgr state code
+                tokens <- liftIO $ runReaderT (O.getValidTokens store mgr state code) oidc
                 blaze $ htmlResult tokens
             Nothing  -> status400 "cookie not found"
 

--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -54,6 +54,7 @@ library
     , exceptions
     , http-client
     , tls               >=1.3.2
+    , mtl
     , http-client-tls
     , jose-jwt          >=0.7
     , cryptonite
@@ -101,6 +102,7 @@ test-suite oidc-client-spec
     , exceptions
     , time
     , network-uri
+    , mtl
 
 executable scotty-example
   main-is:          Main.hs

--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BlockArguments #-}
 {-|
     Module: Web.OIDC.Client.CodeFlow
     Maintainer: krdlab@gmail.com
@@ -61,7 +60,7 @@ prepareAuthenticationRequestUrl
     -> Parameters       -- ^ Optional parameters
     -> ReaderT OIDC m URI
 prepareAuthenticationRequestUrl store scope params = do
-    (state, nonce') <- lift do
+    (state, nonce') <- lift $ do
       state <- sessionStoreGenerate store
       nonce' <- sessionStoreGenerate store
       sessionStoreSave store state nonce'

--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BlockArguments #-}
 {-|
     Module: Web.OIDC.Client.CodeFlow
     Maintainer: krdlab@gmail.com
@@ -36,6 +37,7 @@ import           Network.HTTP.Client                (Manager, Request (..),
                                                      setQueryString,
                                                      urlEncodedBody)
 import           Network.URI                        (URI)
+import           Control.Monad.Reader               (ReaderT(..), ask, lift)
 
 import           Prelude                            hiding (exp)
 
@@ -55,33 +57,34 @@ import           Web.OIDC.Client.Types              (Code, Nonce,
 prepareAuthenticationRequestUrl
     :: (MonadThrow m, MonadCatch m)
     => SessionStore m
-    -> OIDC
     -> Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
     -> Parameters       -- ^ Optional parameters
-    -> m URI
-prepareAuthenticationRequestUrl store oidc scope params = do
-    state <- sessionStoreGenerate store
-    nonce' <- sessionStoreGenerate store
-    sessionStoreSave store state nonce'
-    getAuthenticationRequestUrl oidc scope (Just state) $ params ++ [("nonce", Just nonce')]
+    -> ReaderT OIDC m URI
+prepareAuthenticationRequestUrl store scope params = do
+    (state, nonce') <- lift do
+      state <- sessionStoreGenerate store
+      nonce' <- sessionStoreGenerate store
+      sessionStoreSave store state nonce'
+      pure (state,nonce')
+
+    getAuthenticationRequestUrl scope (Just state) $ params ++ [("nonce", Just nonce')]
 
 -- | Get and validate access token and with code and state stored in the 'SessionStore'.
 --   Then deletes session info by 'sessionStoreDelete'.
 getValidTokens
     :: (MonadThrow m, MonadCatch m, MonadIO m, FromJSON a)
     => SessionStore m
-    -> OIDC
     -> Manager
     -> State
     -> Code
-    -> m (Tokens a)
-getValidTokens store oidc mgr stateFromIdP code = do
-    (state, savedNonce) <- sessionStoreGet store
+    -> ReaderT OIDC m (Tokens a)
+getValidTokens store mgr stateFromIdP code = do
+    (state, savedNonce) <- lift (sessionStoreGet store)
     if state == Just stateFromIdP
       then do
           when (isNothing savedNonce) $ throwM $ ValidationException "Nonce is not saved!"
-          result <- liftIO $ requestTokens oidc savedNonce code mgr
-          sessionStoreDelete store
+          result <- requestTokens savedNonce code mgr
+          lift (sessionStoreDelete store)
           return result
       else throwM $ ValidationException $ "Inconsistent state: " <> decodeUtf8With lenientDecode stateFromIdP
 
@@ -89,27 +92,28 @@ getValidTokens store oidc mgr stateFromIdP code = do
 {-# WARNING getAuthenticationRequestUrl "This function doesn't manage state and nonce. Use prepareAuthenticationRequestUrl only unless your IdP doesn't support state and/or nonce." #-}
 getAuthenticationRequestUrl
     :: (MonadThrow m, MonadCatch m)
-    => OIDC
-    -> Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
+    => Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
     -> Maybe State      -- ^ used for CSRF mitigation. (recommended parameter)
     -> Parameters       -- ^ Optional parameters
-    -> m URI
-getAuthenticationRequestUrl oidc scope state params = do
-    req <- parseUrl endpoint `catch` I.rethrow
-    return $ getUri $ setQueryString query req
-  where
-    endpoint  = oidcAuthorizationServerUrl oidc
-    query     = requireds ++ state' ++ params
-    requireds =
-        [ ("response_type", Just "code")
-        , ("client_id",     Just $ oidcClientId oidc)
-        , ("redirect_uri",  Just $ oidcRedirectUri oidc)
-        , ("scope",         Just $ B.pack . unwords . nub . map unpack $ openId:scope)
-        ]
-    state' =
-        case state of
+    -> ReaderT OIDC m URI
+getAuthenticationRequestUrl scope state params = do
+    oidc <- ask
+
+    let endpoint  = oidcAuthorizationServerUrl oidc
+    let state' =
+          case state of
             Just _  -> [("state", state)]
             Nothing -> []
+    let requireds =
+          [ ("response_type", Just "code")
+          , ("client_id",     Just $ oidcClientId oidc)
+          , ("redirect_uri",  Just $ oidcRedirectUri oidc)
+          , ("scope",         Just $ B.pack . unwords . nub . map unpack $ openId:scope)
+          ]
+    let query     = requireds ++ state' ++ params
+
+    req <- parseUrl endpoint `catch` I.rethrow
+    return $ getUri $ setQueryString query req
 
 -- TODO: error response
 
@@ -120,36 +124,48 @@ getAuthenticationRequestUrl oidc scope state params = do
 --
 -- If a HTTP error has occurred or a tokens validation has failed, this function throws `OpenIdException`.
 {-# WARNING requestTokens "This function doesn't manage state and nonce. Use getValidTokens only unless your IdP doesn't support state and/or nonce." #-}
-requestTokens :: FromJSON a => OIDC -> Maybe Nonce -> Code -> Manager -> IO (Tokens a)
-requestTokens oidc savedNonce code manager = do
-    json <- getTokensJson `catch` I.rethrow
-    case eitherDecode json of
-        Right ts -> validate oidc savedNonce ts
-        Left err -> throwM . JsonException $ pack err
-  where
-    getTokensJson = do
-        req <- parseUrl endpoint
-        let req' = urlEncodedBody body $ req { method = "POST" }
-        res <- httpLbs req' manager
-        return $ responseBody res
-    endpoint = oidcTokenEndpoint oidc
-    cid      = oidcClientId oidc
-    sec      = oidcClientSecret oidc
-    redirect = oidcRedirectUri oidc
-    body     =
-        [ ("grant_type",    "authorization_code")
-        , ("code",          code)
-        , ("client_id",     cid)
-        , ("client_secret", sec)
-        , ("redirect_uri",  redirect)
-        ]
+requestTokens
+    :: (MonadThrow m, MonadIO m, FromJSON a)
+    => Maybe Nonce
+    -> Code
+    -> Manager
+    -> ReaderT OIDC m (Tokens a)
+requestTokens savedNonce code manager = do
+    oidc <- ask
 
-validate :: FromJSON a => OIDC -> Maybe Nonce -> I.TokensResponse -> IO (Tokens a)
-validate oidc savedNonce tres = do
+    let endpoint = oidcTokenEndpoint oidc
+    let cid      = oidcClientId oidc
+    let sec      = oidcClientSecret oidc
+    let redirect = oidcRedirectUri oidc
+    let body     =
+          [ ("grant_type",    "authorization_code")
+          , ("code",          code)
+          , ("client_id",     cid)
+          , ("client_secret", sec)
+          , ("redirect_uri",  redirect)
+          ]
+    let getTokensJson = do
+          req <- parseUrl endpoint
+          let req' = urlEncodedBody body $ req { method = "POST" }
+          res <- httpLbs req' manager
+          return $ responseBody res
+
+    json <- liftIO (getTokensJson `catch` I.rethrow)
+    case eitherDecode json of
+        Right ts -> validate savedNonce ts
+        Left err -> throwM . JsonException $ pack err
+
+validate
+    :: (MonadThrow m, MonadIO m, FromJSON a)
+    => Maybe Nonce
+    -> I.TokensResponse
+    -> ReaderT OIDC m (Tokens a)
+validate savedNonce tres = do
+    oidc <- ask
     let jwt' = I.idToken tres
     claims' <- validateIdToken oidc jwt'
     now <- getCurrentIntDate
-    validateClaims
+    liftIO $ validateClaims
         (P.issuer . P.configuration . oidcProvider $ oidc)
         (decodeUtf8With lenientDecode . oidcClientId $ oidc)
         now
@@ -164,7 +180,13 @@ validate oidc savedNonce tres = do
         , refreshToken = I.refreshToken tres
         }
 
-validateClaims :: Text -> Text -> Jwt.IntDate -> Maybe Nonce -> IdTokenClaims a -> IO ()
+validateClaims
+    :: Text
+    -> Text
+    -> Jwt.IntDate
+    -> Maybe Nonce
+    -> IdTokenClaims a
+    -> IO ()
 validateClaims issuer' clientId' now savedNonce claims' = do
     let iss' = iss claims'
     unless (iss' == issuer')
@@ -180,5 +202,5 @@ validateClaims issuer' clientId' now savedNonce claims' = do
     unless (nonce claims' == savedNonce)
         $ throwM $ ValidationException "Inconsistent nonce"
 
-getCurrentIntDate :: IO Jwt.IntDate
-getCurrentIntDate = Jwt.IntDate <$> getPOSIXTime
+getCurrentIntDate :: MonadIO m => m Jwt.IntDate
+getCurrentIntDate = Jwt.IntDate <$> liftIO getPOSIXTime

--- a/src/Web/OIDC/Client/IdTokenFlow.hs
+++ b/src/Web/OIDC/Client/IdTokenFlow.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BlockArguments #-}
 {-|
     Module: Web.OIDC.Client.CodeFlow
     Maintainer: krdlab@gmail.com
@@ -46,7 +45,7 @@ prepareAuthenticationRequestUrl
     -> Parameters       -- ^ Optional parameters
     -> ReaderT OIDC m URI
 prepareAuthenticationRequestUrl store scope params = do
-    (state,nonce') <- lift do
+    (state,nonce') <- lift $ do
       state <- sessionStoreGenerate store
       nonce' <- sessionStoreGenerate store
       sessionStoreSave store state nonce'

--- a/src/Web/OIDC/Client/IdTokenFlow.hs
+++ b/src/Web/OIDC/Client/IdTokenFlow.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BlockArguments #-}
 {-|
     Module: Web.OIDC.Client.CodeFlow
     Maintainer: krdlab@gmail.com
@@ -25,7 +26,7 @@ import           Data.Text.Encoding.Error           (lenientDecode)
 import qualified Jose.Jwt                           as Jwt
 import           Network.HTTP.Client                (getUri, setQueryString)
 import           Network.URI                        (URI)
-
+import           Control.Monad.Reader               (ReaderT(..), ask, lift)
 import           Prelude                            hiding (exp)
 
 import           Web.OIDC.Client.Internal           (parseUrl)
@@ -41,32 +42,34 @@ import           Web.OIDC.Client.Types              (OpenIdException (..),
 prepareAuthenticationRequestUrl
     :: (MonadIO m)
     => SessionStore m
-    -> OIDC
     -> Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
     -> Parameters       -- ^ Optional parameters
-    -> m URI
-prepareAuthenticationRequestUrl store oidc scope params = do
-    state <- sessionStoreGenerate store
-    nonce' <- sessionStoreGenerate store
-    sessionStoreSave store state nonce'
-    getAuthenticationRequestUrl oidc scope (Just state) $ params ++ [("nonce", Just nonce')]
+    -> ReaderT OIDC m URI
+prepareAuthenticationRequestUrl store scope params = do
+    (state,nonce') <- lift do
+      state <- sessionStoreGenerate store
+      nonce' <- sessionStoreGenerate store
+      sessionStoreSave store state nonce'
+      pure (state,nonce')
+
+    getAuthenticationRequestUrl scope (Just state) $ params ++ [("nonce", Just nonce')]
 
 -- | Get and validate access token and with code and state stored in the 'SessionStore'.
 --   Then deletes session info by 'sessionStoreDelete'.
 getValidIdTokenClaims
     :: (MonadIO m, FromJSON a)
     => SessionStore m
-    -> OIDC
     -> State
     -> m B.ByteString
-    -> m (IdTokenClaims a)
-getValidIdTokenClaims store oidc stateFromIdP getIdToken = do
-    (state, savedNonce) <- sessionStoreGet store
+    -> ReaderT OIDC m (IdTokenClaims a)
+getValidIdTokenClaims store stateFromIdP getIdToken = do
+    oidc <- ask
+    (state, savedNonce) <- lift (sessionStoreGet store)
     if state == Just stateFromIdP
       then do
           when (isNothing savedNonce) $ liftIO $ throwIO $ ValidationException "Nonce is not saved!"
-          jwt <- Jwt.Jwt <$> getIdToken
-          sessionStoreDelete store
+          jwt <- Jwt.Jwt <$> lift getIdToken
+          lift (sessionStoreDelete store)
           idToken <- liftIO $ validateIdToken oidc jwt
           when (fromMaybe True $ (/=) <$> savedNonce <*> nonce idToken)
                 $ liftIO
@@ -79,25 +82,26 @@ getValidIdTokenClaims store oidc stateFromIdP getIdToken = do
 {-# WARNING getAuthenticationRequestUrl "This function doesn't manage state and nonce. Use prepareAuthenticationRequestUrl only unless your IdP doesn't support state and/or nonce." #-}
 getAuthenticationRequestUrl
     :: (MonadIO m)
-    => OIDC
-    -> Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
+    => Scope            -- ^ used to specify what are privileges requested for tokens. (use `ScopeValue`)
     -> Maybe State      -- ^ used for CSRF mitigation. (recommended parameter)
     -> Parameters       -- ^ Optional parameters
-    -> m URI
-getAuthenticationRequestUrl oidc scope state params = do
-    req <- liftIO $ parseUrl endpoint `catch` I.rethrow
-    return $ getUri $ setQueryString query req
-  where
-    endpoint  = oidcAuthorizationServerUrl oidc
-    query     = requireds ++ state' ++ params
-    requireds =
-        [ ("response_type", Just "id_token")
-        , ("response_mode", Just "form_post")
-        , ("client_id",     Just $ oidcClientId oidc)
-        , ("redirect_uri",  Just $ oidcRedirectUri oidc)
-        , ("scope",         Just . B.pack . unwords . nub . map unpack $ openId:scope)
-        ]
-    state' =
-        case state of
+    -> ReaderT OIDC m URI
+getAuthenticationRequestUrl scope state params = do
+    oidc <- ask
+
+    let state' =
+          case state of
             Just _  -> [("state", state)]
             Nothing -> []
+    let endpoint = oidcAuthorizationServerUrl oidc
+    let requireds =
+          [ ("response_type", Just "id_token")
+          , ("response_mode", Just "form_post")
+          , ("client_id",     Just $ oidcClientId oidc)
+          , ("redirect_uri",  Just $ oidcRedirectUri oidc)
+          , ("scope",         Just . B.pack . unwords . nub . map unpack $ openId:scope)
+          ]
+    let query     = requireds ++ state' ++ params
+
+    req <- liftIO $ parseUrl endpoint `catch` I.rethrow
+    return $ getUri $ setQueryString query req

--- a/test/Spec/Client.hs
+++ b/test/Spec/Client.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BlockArguments #-}
 module Spec.Client where
 
 import           Data.Aeson              (Value (Null))

--- a/test/Spec/Client.hs
+++ b/test/Spec/Client.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -Wno-warnings-deprecations #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BlockArguments #-}
 module Spec.Client where
 
 import           Data.Aeson              (Value (Null))
@@ -12,6 +13,7 @@ import           Network.HTTP.Types      (urlEncode)
 import           Test.Hspec              (Spec, describe, it, shouldContain,
                                           shouldNotContain, shouldThrow)
 import           Web.OIDC.Client
+import           Control.Monad.Reader    (runReaderT)
 
 import           Prelude                 hiding (exp)
 
@@ -29,7 +31,7 @@ tests = do
             manager  <- newManager tlsManagerSettings
             provider <- discover google manager
             let oidc = setCredentials clientId clientSecret redirectUri $ newOIDC provider
-            url <- getAuthenticationRequestUrl oidc [] Nothing []
+            url <- runReaderT (getAuthenticationRequestUrl [] Nothing []) oidc
             show url `shouldContain` "response_type=code"
             show url `shouldContain` "scope=openid"
             show url `shouldContain` (toES "client_id" ++ "=" ++ toES clientId)
@@ -41,7 +43,7 @@ tests = do
             provider <- discover google manager
             let oidc = setCredentials clientId clientSecret redirectUri $ newOIDC provider
                 state = "dummy state"
-            url <- getAuthenticationRequestUrl oidc [email] (Just state) [("nonce", Just nonce')]
+            url <- runReaderT (getAuthenticationRequestUrl [email] (Just state) [("nonce", Just nonce')]) oidc
             show url `shouldContain` (toES "scope" ++ "=" ++ toES "openid email")
             show url `shouldContain` (toES "state" ++ "=" ++ toES state)
             show url `shouldContain` (toES "nonce" ++ "=" ++ toES nonce')


### PR DESCRIPTION
The primary reason for this change is to pave the way for user-defined HTTP manager / request settings that need to be carried with the OIDC settings (but do not really belong in the data type itself). ReaderT is more natural anyway for carrying the OIDC settings around to all the different functions that need it.

There's some very minor refactoring activity (e.g using local let bindings instead of where bindings), I tried to keep it specific to the addition of the ReaderT type though.

I know this is an API lift, so it likely requires a new minor version bump if this change is accepted.