### PR TITLE
Remove max version cap on bytestring and min >= 0.11

### DIFF
--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -46,7 +46,7 @@ library
       Web.OIDC.Client.Internal
   build-depends:
       base              >=4.7 && <5
-    , bytestring        >=0.10 && <0.11
+    , bytestring        >=0.10
     , text              >=1.2 && <1.3
     , aeson             >=0.10
     , scientific


### PR DESCRIPTION
Hi, could it be possible to remove the max cap on bytestring ? I'd like to integrate oidc-client but it conflict with other deps of my app.
Thanks in advance.