### PR TITLE
Lookup by state with sessionStoreGet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [0.7.0.0]
+
+- Lookup by state with sessionStoreGet
+
 ## [0.6.1.0]
 - Remove max version cap on bytestring and min >= 0.11 ([#54](https://github.com/krdlab/haskell-oidc-client/pull/54))
 

--- a/examples/scotty/Main.hs
+++ b/examples/scotty/Main.hs
@@ -155,11 +155,11 @@ run' = do
     genSessionId cprg          = liftIO $ decodeUtf8 <$> gen cprg
     genBytes cprg              = liftIO $ gen cprg
     saveState ssm sid st nonce = liftIO $ atomicModifyIORef' ssm $ \m -> (M.insert sid (st, nonce) m, ())
-    getStateBy ssm sid         = liftIO $ do
+    getStateBy ssm sid _st     = liftIO $ do
         m <- M.lookup sid <$> readIORef ssm
         return $ case m of
-            Just (st, nonce) -> (Just st, Just nonce)
-            _                -> (Nothing, Nothing)
+            Just (_, nonce) -> Just nonce
+            _               -> Nothing
     deleteState ssm sid  = liftIO $ atomicModifyIORef' ssm $ \m -> (M.delete sid m, ())
 
     sessionStoreFromSession cprg ssm sid =

--- a/src/Web/OIDC/Client/Types.hs
+++ b/src/Web/OIDC/Client/Types.hs
@@ -55,6 +55,9 @@ data OpenIdException =
     | UnsecuredJwt ByteString
     | JwtException JwtError
     | ValidationException Text
+    | UnknownState
+    | MissingNonceInResponse
+    | MismatchedNonces
   deriving (Show, Typeable)
 
 instance Exception OpenIdException
@@ -64,8 +67,9 @@ instance Exception OpenIdException
 data SessionStore m = SessionStore
     { sessionStoreGenerate :: m ByteString
     -- ^ Generate state and nonce at random
-    , sessionStoreSave     :: State -> Nonce -> m ()
-    , sessionStoreGet      :: m (Maybe State, Maybe Nonce)
-    , sessionStoreDelete   :: m ()
+    , sessionStoreSave :: State -> Nonce -> m ()
+    , sessionStoreGet :: State -> m (Maybe Nonce)
+    -- ^ Returns 'Nothing' if 'State' is unknown
+    , sessionStoreDelete :: m ()
     -- ^ Should delete at least nonce
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
 - jose-jwt-0.9.4@sha256:6db77f81cfcf81cf7faf8a4dc4b2110c1603dbb94249d49d069a17b4897e9d69,3560
+- scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9,1204
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,19 @@
-resolver: lts-18.28
+resolver: lts-19.16
 
 packages:
   - '.'
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
-- scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9
+- jose-jwt-0.9.4@sha256:6db77f81cfcf81cf7faf8a4dc4b2110c1603dbb94249d49d069a17b4897e9d69,3560
 
 # Override default flag values for local packages and extra-deps
 flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []
+
+nix:
+  packages:
+  - ghc
+  - zlib


### PR DESCRIPTION
Up streaming the changes done by Michael Snoyman. I'm additionally bumping the lts resolver and adding changelog too.

Motivation of the changes:
- We want the ability to lookup session store by state. This was common for workflows where multiple browser tabs are trying to log in at once.
- Make it much easier to debug by explicitly throwing different exceptions for different errors.

We have been using this change for more than 2 years in our production now and it has been working well for us.
