### PR TITLE
chore: bump the text bound

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,13 +20,14 @@ jobs:
           - lts-17
           - lts-18
           - lts-19
+          - lts-20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v2
         with:
-          ghc-version: '8.10.2'
-          cabal-version: '3.4.0.0'
+          ghc-version: '9.2.5'
+          cabal-version: '3.8.1.0'
 
       - uses: actions/cache@v2
         env:

--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -47,7 +47,7 @@ library
   build-depends:
       base              >=4.7 && <5
     , bytestring        >=0.10
-    , text              >=1.2 && <1.3
+    , text              (>=1.2 && <1.3) || (>= 2.0 && < 2.1)
     , aeson             >=0.10
     , scientific
     , attoparsec        >=0.12


### PR DESCRIPTION
This is necessary for GHC 9.4 support :)

I actually wanted to add testing on 9.4, but that's blocked on aeson bounds fixes on jose-jwt: https://github.com/tekul/jose-jwt/pull/38

Can you publish a Hackage metadata revision with these bounds? Thanks!