### PR TITLE
Switch to crypton

### DIFF
--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -1,5 +1,5 @@
 name:               oidc-client
-version:            0.7.0.1
+version:            0.8.0.0
 synopsis:           OpenID Connect 1.0 library for RP
 homepage:           https://github.com/krdlab/haskell-oidc-client
 stability:          experimental
@@ -56,7 +56,7 @@ library
     , tls               >=1.3.2
     , http-client-tls
     , jose-jwt          >=0.7
-    , cryptonite
+    , crypton
     , time
   if flag(network-uri)
     build-depends: network-uri >=2.6, network >=2.6
@@ -97,7 +97,7 @@ test-suite oidc-client-spec
     , aeson
     , scientific
     , jose-jwt
-    , cryptonite
+    , crypton
     , exceptions
     , time
     , network-uri

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,6 +7,7 @@ packages:
 extra-deps:
 - jose-jwt-0.9.4@sha256:6cb863760068a57ebf6dcc6efc6463162e71f932fe1134a69c9c0baa5d6d13f6,3692
 - scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9,1204
+- crypton-0.33@sha256:5e92f29b9b7104d91fcdda1dec9400c9ad1f1791c231cc41ceebd783fb517dee,18202
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
cryptonite is no longer being maintained. The community is migrating to a fork of cryptonite, called crypton. Here are some contexts:

- [Reddit post on creating the new fork](https://www.reddit.com/r/haskell/comments/14245q8/crypton_is_forked_from_cryptonite_with_the/)
- Some core libraries, including [warp](https://github.com/yesodweb/wai/pull/931), has migrated to crypton