### PR TITLE
support ghc 9.8

### DIFF
--- a/oidc-client.cabal
+++ b/oidc-client.cabal
@@ -47,7 +47,7 @@ library
   build-depends:
       base              >=4.7 && <5
     , bytestring        >=0.10
-    , text              (>=1.2 && <1.3) || (>= 2.0 && < 2.1)
+    , text              (>=1.2 && <1.3) || (>= 2.0 && < 2.2)
     , aeson             >=0.10
     , scientific
     , attoparsec        >=0.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,13 @@
-resolver: lts-19.16
+resolver: nightly-2024-03-07
 
 packages:
-  - '.'
+  - "."
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 extra-deps:
-- jose-jwt-0.9.4@sha256:6cb863760068a57ebf6dcc6efc6463162e71f932fe1134a69c9c0baa5d6d13f6,3692
-- scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9,1204
-- crypton-0.33@sha256:5e92f29b9b7104d91fcdda1dec9400c9ad1f1791c231cc41ceebd783fb517dee,18202
+  - jose-jwt-0.10.0@sha256:6ed175a01c721e317ceea15eb251a81de145c03711a977517935633a5cdec1d4,3546
+  - scotty-cookie-0.1.0.3@sha256:3ff1df13a5acba8ba170a5ac22b3ac6a2c227791292536ce1ebfc41038f58fc9,1204
+  - crypton-0.34@sha256:9e4b50d79d1fba681befa08151db7223d2b4bb72564853e8530e614105d53a1a,14577
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Bumps the `text` bound as mentioned in #63