### PR TITLE
Add state argument to delete

### DIFF
--- a/examples/scotty/Main.hs
+++ b/examples/scotty/Main.hs
@@ -167,7 +167,7 @@ run' = do
             { sessionStoreGenerate = genBytes cprg
             , sessionStoreSave     = saveState ssm sid
             , sessionStoreGet      = getStateBy ssm sid
-            , sessionStoreDelete   = deleteState ssm sid
+            , sessionStoreDelete   = const $ deleteState ssm sid 
             }
 
     blaze = html . renderHtml

--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -79,7 +79,7 @@ getValidTokens store oidc mgr stateFromIdP code = do
     savedNonce <- sessionStoreGet store stateFromIdP
     when (isNothing savedNonce) $ throwM UnknownState
     result <- liftIO $ requestTokens oidc savedNonce code mgr
-    sessionStoreDelete store
+    sessionStoreDelete store stateFromIdP
     return result
 
 -- | Make URL for Authorization Request.

--- a/src/Web/OIDC/Client/IdTokenFlow.hs
+++ b/src/Web/OIDC/Client/IdTokenFlow.hs
@@ -64,7 +64,7 @@ getValidIdTokenClaims store oidc stateFromIdP getIdToken = do
     msavedNonce <- sessionStoreGet store stateFromIdP
     savedNonce <- maybe (liftIO $ throwIO UnknownState) pure msavedNonce
     jwt <- Jwt.Jwt <$> getIdToken
-    sessionStoreDelete store
+    sessionStoreDelete store stateFromIdP
     idToken <- liftIO $ validateIdToken oidc jwt
     nonce' <- maybe (liftIO $ throwIO MissingNonceInResponse) pure (nonce idToken)
     when (nonce' /= savedNonce) $ liftIO $ throwIO MismatchedNonces

--- a/src/Web/OIDC/Client/Types.hs
+++ b/src/Web/OIDC/Client/Types.hs
@@ -70,6 +70,6 @@ data SessionStore m = SessionStore
     , sessionStoreSave :: State -> Nonce -> m ()
     , sessionStoreGet :: State -> m (Maybe Nonce)
     -- ^ Returns 'Nothing' if 'State' is unknown
-    , sessionStoreDelete :: m ()
+    , sessionStoreDelete :: State -> m ()
     -- ^ Should delete at least nonce
     }


### PR DESCRIPTION
This PR also includes diff changes from #65

All call sites of `sessionStoreDelete` have access to the state argument, and in my case I want to only clear the state for a specific authentication request (not all of them), therefore I need to identify which entry I am going to remove.

I could parameterize my entire session store by `State` but that is kind of clunky and doesn't allow me to simply define the session store once.