### PR TITLE
Export validate function

### DIFF
--- a/src/Web/OIDC/Client/CodeFlow.hs
+++ b/src/Web/OIDC/Client/CodeFlow.hs
@@ -10,6 +10,7 @@ module Web.OIDC.Client.CodeFlow
     , getValidTokens
     , prepareAuthenticationRequestUrl
     , requestTokens
+    , validate
 
     -- * For testing
     , validateClaims


### PR DESCRIPTION
I needed this lower-level function to have a little more control over the OIDC flow. In my case, I wanted to manage the HTTP request myself and do some logging around it. 

This `validate` function is essentially the core part of the `requestTokens` function, minus the constructing/sending/decoding the request, so I think it's useful to export in its own right.