### PR TITLE
Fix release.nix

### DIFF
--- a/nix/21_05.nix
+++ b/nix/21_05.nix
@@ -1,4 +1,0 @@
-(import ./fetchNixpkgs.nix) {
-  rev    = "7e9b0dff974c89e070da1ad85713ff3c20b0ca97";
-  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
-}

--- a/nix/24_05.nix
+++ b/nix/24_05.nix
@@ -1,0 +1,4 @@
+(import ./fetchNixpkgs.nix) {
+  rev    = "63dacb46bf939521bdc93981b4cbb7ecb58427a0";
+  sha256 = "sha256:1lr1h35prqkd1mkmzriwlpvxcb34kmhc9dnr48gkm8hh089hifmx";
+}

--- a/release.nix
+++ b/release.nix
@@ -12,7 +12,7 @@ let
     })
   ];
 
-  nixpkgs = import ./nix/21_05.nix;
+  nixpkgs = import ./nix/24_05.nix;
   pkgs    = import nixpkgs { inherit config overlays; };
 
   oidc-client-shell = pkgs.haskellPackages.shellFor {

--- a/release.nix
+++ b/release.nix
@@ -2,10 +2,11 @@ let
   config   = { allowUnfree = true; };
   overlays = [
     (newPkgs: oldPkgs: rec {
-
       haskellPackages = oldPkgs.haskellPackages.override {
         overrides = haskellPackagesNew: _: {
-          oidc-client = haskellPackagesNew.callCabal2nix "oidc-client" ./. { };
+          # disable tests because the discovery tests use the internet, which
+          # fails in the sandbox
+          oidc-client = oldPkgs.haskell.lib.dontCheck (haskellPackagesNew.callCabal2nix "oidc-client" ./. { });
         };
       };
 


### PR DESCRIPTION
`release.nix` stopped working when the library switched to `crypton` because that library was first uploaded to Hackage in June 2023 and `release.nix` was using a `nixpkgs` snapshot from early 2021. This PR fixes that and then also disables the tests from running, because nowadays it seems like the tests reach out to Google servers to test discovery, and that doesn't work in the nix sandbox.